### PR TITLE
Fix CI pipeline compilation warnings and doctest errors

### DIFF
--- a/external/dioniceos/apollyon-mef-bridge/examples/storage_integration.rs
+++ b/external/dioniceos/apollyon-mef-bridge/examples/storage_integration.rs
@@ -6,7 +6,6 @@
 use apollyon_mef_bridge::storage::{LedgerStorage, MemoryStorage, StorageBackend};
 use apollyon_mef_bridge::unified::{CognitiveInput, UnifiedCognitiveEngine};
 use core_5d::{State5D, SystemParameters};
-use std::path::Path;
 use tempfile::TempDir;
 
 #[tokio::main]

--- a/external/dioniceos/apollyon-mef-bridge/src/storage/memory_storage.rs
+++ b/external/dioniceos/apollyon-mef-bridge/src/storage/memory_storage.rs
@@ -148,7 +148,7 @@ impl Clone for CognitiveOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core_5d::{State5D, SystemParameters};
+    use core_5d::State5D;
     use mef_schemas::{GateDecision, KnowledgeObject, RouteSpec, SpectralSignature};
 
     fn create_test_output() -> CognitiveOutput {

--- a/external/dioniceos/infinity-ledger/mef-core/src/gabriel_cell.rs
+++ b/external/dioniceos/infinity-ledger/mef-core/src/gabriel_cell.rs
@@ -276,7 +276,7 @@ mod tests {
         let mut cell = GabrielCell::new(2.0, 1.0, 1.0, 0.1);
         let target = 1.0;
 
-        let initial_output = cell.output;
+        let _initial_output = cell.output;
         cell.feedback(target);
 
         // Error = 1.0 - 2.0 = -1.0
@@ -378,7 +378,7 @@ mod tests {
         couple_cells(&mut cells, 0, 1);
         couple_cells(&mut cells, 0, 2);
 
-        let avg_neighbor_output = (cells[1].output + cells[2].output) / 2.0;
+        let _avg_neighbor_output = (cells[1].output + cells[2].output) / 2.0;
 
         neighbor_feedback(&mut cells, 0);
 

--- a/external/dioniceos/infinity-ledger/mef-core/src/mandorla.rs
+++ b/external/dioniceos/infinity-ledger/mef-core/src/mandorla.rs
@@ -386,7 +386,7 @@ mod tests {
         field.add_input(array![1.0, 2.0, 3.0, 4.0]);
         field.add_input(array![1.1, 2.1, 3.1, 4.1]);
 
-        let triggered = field.decision_trigger();
+        let _triggered = field.decision_trigger();
         // current_theta should be α·Entropy + β·Variance
         let expected_theta = 0.5 * field.calc_entropy() + 0.5 * field.calc_variance();
         assert!((field.current_theta - expected_theta).abs() < 1e-10);

--- a/external/dioniceos/overlay/unified_5d_cube/examples/all_extensions.rs
+++ b/external/dioniceos/overlay/unified_5d_cube/examples/all_extensions.rs
@@ -4,7 +4,6 @@
 
 use apollyon_mef_bridge::trichter::Policy;
 use core_5d::State5D;
-use std::path::PathBuf;
 use tempfile::TempDir;
 use unified_5d_cube::{tick_5d_cube, InterlockAdapter, InterlockConfig};
 

--- a/external/dioniceos/overlay/unified_5d_cube/examples/ledger_writes.rs
+++ b/external/dioniceos/overlay/unified_5d_cube/examples/ledger_writes.rs
@@ -3,7 +3,6 @@
 //! Run with: cargo run --example ledger_writes
 
 use core_5d::State5D;
-use std::path::PathBuf;
 use tempfile::TempDir;
 use unified_5d_cube::{tick_5d_cube, InterlockAdapter, InterlockConfig};
 

--- a/external/dioniceos/overlay/unified_5d_cube/examples/metatron_routing.rs
+++ b/external/dioniceos/overlay/unified_5d_cube/examples/metatron_routing.rs
@@ -3,7 +3,6 @@
 //! Run with: cargo run --example metatron_routing
 
 use core_5d::State5D;
-use std::path::PathBuf;
 use tempfile::TempDir;
 use unified_5d_cube::{tick_5d_cube, InterlockAdapter, InterlockConfig};
 

--- a/metatron-qso-rs/src/lib.rs
+++ b/metatron-qso-rs/src/lib.rs
@@ -22,17 +22,21 @@
 //! // Create the Metatron graph
 //! let graph = MetatronGraph::new();
 //!
+//! // Create the Hamiltonian
+//! let params = QSOParameters::default();
+//! let hamiltonian = MetatronHamiltonian::new(&graph, &params);
+//!
 //! // Initialize quantum state on central node
-//! let initial_state = QuantumState::basis_state(0);
+//! let initial_state = QuantumState::basis_state(0)?;
 //!
 //! // Run quantum walk
-//! let qw = ContinuousTimeQuantumWalk::new(graph);
-//! let evolved = qw.evolve(&initial_state, 1.0)?;
+//! let qw = ContinuousTimeQuantumWalk::new(&hamiltonian);
+//! let evolved = qw.evolve(&initial_state, 1.0);
 //!
 //! // Check probability distribution
 //! let probs = evolved.probabilities();
 //! println!("Probability at node 0: {:.4}", probs[0]);
-//! # Ok::<(), String>(())
+//! # Ok::<(), Box<dyn std::error::Error>>(())
 //! ```
 //!
 //! ## Architecture

--- a/metatron_telemetry/src/api/handlers.rs
+++ b/metatron_telemetry/src/api/handlers.rs
@@ -66,6 +66,7 @@ pub async fn get_history(
 #[derive(Debug, Deserialize)]
 pub struct StartCalibrationRequest {
     #[serde(default)]
+    #[allow(dead_code)]
     algorithm: Option<String>,
     #[serde(default)]
     mode: Option<String>,

--- a/metatron_triton/src/spiral.rs
+++ b/metatron_triton/src/spiral.rs
@@ -8,6 +8,7 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 /// Golden ratio φ = (1 + √5) / 2
+#[allow(dead_code)]
 const GOLDEN_RATIO: f64 = 1.618033988749895;
 
 /// Golden angle in radians: 2π / φ²


### PR DESCRIPTION
This commit addresses all warnings and errors that were causing the CI pipeline to fail, making the codebase release-ready.

Changes:
- Fix doctest in metatron-qso-rs/src/lib.rs that had incorrect API usage:
  * Create MetatronHamiltonian from graph and params
  * Handle Result from QuantumState::basis_state()
  * Remove incorrect ? operator from evolve() call

- Silence dead code warnings for intentionally unused fields:
  * metatron_telemetry: algorithm field in StartCalibrationRequest
  * metatron_triton: GOLDEN_RATIO constant

- Remove unused imports from example files:
  * unified_5d_cube examples: Remove unused PathBuf imports
  * apollyon-mef-bridge examples: Remove unused Path import
  * memory_storage tests: Remove unused SystemParameters import

- Prefix intentionally unused test variables with underscore:
  * gabriel_cell tests: _initial_output, _avg_neighbor_output
  * mandorla tests: _triggered

All tests now pass and the build produces no warnings.