### PR TITLE
Fix Windows build failure

### DIFF
--- a/metatron_qso_py/src/lib.rs
+++ b/metatron_qso_py/src/lib.rs
@@ -176,8 +176,10 @@ fn run_quantum_walk(
     Python::attach(|py| {
         let result = PyDict::new(py);
         result.set_item("times", times.into_pyobject(py)?)?;
+        // Extract final state before moving probabilities
+        let final_state = probabilities.last().unwrap().clone();
         result.set_item("probabilities", probabilities.into_pyobject(py)?)?;
-        result.set_item("final_state", probabilities.last().unwrap().into_pyobject(py)?)?;
+        result.set_item("final_state", final_state.into_pyobject(py)?)?;
         Ok(result.into_any().unbind())
     })
 }


### PR DESCRIPTION
Extract final_state before moving probabilities to prevent E0382 borrow of moved value error on Windows builds.