### PR TITLE
Fix incomplete task description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -141,9 +141,12 @@ jobs:
           if grep -q "## \[${VERSION}\]" CHANGELOG.md; then
             NOTES=$(sed -n "/## \[${VERSION}\]/,/## \[/p" CHANGELOG.md | sed '$d')
           else
-            NOTES="Release ${VERSION}
+            NOTES=$(cat <<EOF
+          Release ${VERSION}
 
-See CHANGELOG.md for details."
+          See CHANGELOG.md for details.
+          EOF
+          )
           fi
 
           echo "notes<<EOF" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replace multi-line string literal with here-document on line 146 to resolve YAML parsing error. The here-document format is more compatible with YAML's literal block scalar syntax.